### PR TITLE
dependency fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import mojolly.inflector.InflectorImports._ // this is also a trait
 This library is published to maven-central.
 
 ```scala
-libraryDependencies += "io.backchat.inflector" %% "scala-inflector" % "1.3.4"
+libraryDependencies += "io.backchat.inflector" %% "scala-inflector" % "1.3.5"
 ```
 
 ## Patches


### PR DESCRIPTION
An outdated version is mentioned in the readme. The only available in Maven at the moment is 1.3.5
