### PR TITLE
Cross compile for scala 2.11.11 and 2.12.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import mojolly.inflector.InflectorImports._ // this is also a trait
 This library is published to maven-central.
 
 ```scala
-libraryDependencies += "io.backchat.inflector" %% "scala-inflector" % "1.3.4"
+libraryDependencies += "io.backchat.inflector" %% "scala-inflector" % "1.3.6"
 ```
 
 ## Patches

--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,12 @@ import scala.xml._
 
 name := "scala-inflector"
 
-version := "1.3.6-SNAPSHOT"
+version := "1.3.6"
 
 organization := "io.backchat.inflector"
 
-scalaVersion := "2.12.3"
-crossScalaVersions := Seq("2.11.11", "2.12.3")
+scalaVersion := "2.12.4"
+crossScalaVersions := Seq("2.11.11", "2.12.4")
 
 crossVersion := CrossVersion.binary
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,14 +6,19 @@ version := "1.3.6-SNAPSHOT"
 
 organization := "io.backchat.inflector"
 
-scalaVersion := "2.11.0"
+scalaVersion := "2.12.3"
+crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 crossVersion := CrossVersion.binary
 
-scalacOptions ++= Seq("-optimize", "-unchecked", "-deprecation", "-Xcheckinit", "-encoding", "utf8")
+scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation", "-Xcheckinit", "-encoding", "utf8")
+
+scalacOptions := scalacOptions.value :+ Option(scalaVersion.value).filter(_.startsWith("2.12"))
+  .map(v => "-opt:l:method")
+  .getOrElse("-optimize")
 
 libraryDependencies <+= (scalaVersion) {
-  case v if v.startsWith("2.12") => "org.specs2" %% "specs2-core" % "3.8.5" % "test"
+  case v if v.startsWith("2.12") => "org.specs2" %% "specs2-core" % "3.9.5" % "test"
   case _ => "org.specs2" %% "specs2" % "2.3.11" % "test"
 }
 
@@ -23,8 +28,6 @@ libraryDependencies ++= Seq(
 )
 
 autoCompilerPlugins := true
-
-crossScalaVersions := Seq("2.11.0", "2.12.0-RC1")
 
 parallelExecution in Test := false
 

--- a/src/main/scala/Inflector.scala
+++ b/src/main/scala/Inflector.scala
@@ -3,6 +3,7 @@ package mojolly.inflector
 import java.util.Locale.ENGLISH
 import scala.Some
 import annotation.tailrec
+import scala.language.implicitConversions
 import scala.util.matching.Regex
 
 trait Inflector {


### PR DESCRIPTION
The updates the inflector library to cross compile for scala 2.11.11 and 2.12.3.

Could you please publish version 1.3.6 once this is merged?

Thanks!